### PR TITLE
Update package.json to use newer eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "description": "Note: double curly-braces because python .format",
     "version": "0.0.0",
     "scripts": {
-        "preinstall": "npm install eslint@1.3.1 -g"
+        "preinstall": "npm install eslint@1.6.0"
     }
 }


### PR DESCRIPTION
Get an error message when installing old @1.3.1 version:
> git commit -m "with semicolon"
[INFO] Installing environment for https://github.com/pre-commit/mirrors-eslint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
eslint...................................................................Failed
hookid: eslint

module.js:339
    throw err;
    ^

Error: Cannot find module 'eslint-plugin-react'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at /Users/tmbp/.pre-commit/repoW3jAGU/node_env-default/lib/node_modules/eslint/lib/cli-engine.js:106:26
    at Array.forEach (native)
    at loadPlugins (/Users/tmbp/.pre-commit/repoW3jAGU/node_env-default/lib/node_modules/eslint/lib/cli-engine.js:97:21)
    at processText (/Users/tmbp/.pre-commit/repoW3jAGU/node_env-default/lib/node_modules/eslint/lib/cli-engine.js:182:5)
    at processFile (/Users/tmbp/.pre-commit/repoW3jAGU/node_env-default/lib/node_modules/eslint/lib/cli-engine.js:224:12)
    at /Users/tmbp/.pre-commit/repoW3jAGU/node_env-default/lib/node_modules/eslint/lib/cli-engine.js:391:26