### PR TITLE
Refer to additional_dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ Add this to your `.pre-commit-config.yaml`:
         sha: ''  # Use the sha you want to point at
         hooks:
         -   id: eslint
+
+When using plugins with `eslint` you'll need to declare theme under
+`additional_dependencies`. For example:
+
+    -   repo: git://github.com/pre-commit/mirrors-eslint
+        sha: ''  # Use the sha you want to point at
+        hooks:
+        -   id: eslint
+            additional_dependencies:
+            -   eslint-config-google@0.7.1
+            -   eslint-loader@1.6.1
+            -   eslint-plugin-react@6.10.3
+            -   babel-eslint@6.1.2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `.pre-commit-config.yaml`:
         hooks:
         -   id: eslint
 
-When using plugins with `eslint` you'll need to declare theme under
+When using plugins with `eslint` you'll need to declare them under
 `additional_dependencies`. For example:
 
     -   repo: git://github.com/pre-commit/mirrors-eslint


### PR DESCRIPTION
Since this seems to be a common use-case for `eslint` I thought it could go in the README.